### PR TITLE
加入一个autosave_global_key的配置用与一些用ajax的场景

### DIFF
--- a/lib/simditor-autosave.js
+++ b/lib/simditor-autosave.js
@@ -1,31 +1,25 @@
 (function (root, factory) {
   if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define('simditor-autosave', ["jquery",
-      "simple-module",
-      "simditor"], function ($, SimpleModule, Simditor) {
-      return (root.returnExportsGlobal = factory($, SimpleModule, Simditor));
+    // AMD. Register as an anonymous module unless amdModuleId is set
+    define('simditor-autosave', ["jquery","simple-module","simditor"], function (a0,b1,c2) {
+      return (root['SimditorAutosave'] = factory(a0,b1,c2));
     });
   } else if (typeof exports === 'object') {
     // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like enviroments that support module.exports,
+    // only CommonJS-like environments that support module.exports,
     // like Node.
-    module.exports = factory(require("jquery"),
-      require("simple-module"),
-      require("simditor"));
+    module.exports = factory(require("jquery"),require("simple-module"),require("simditor"));
   } else {
-    root['SimditorAutosave'] = factory(jQuery,
-      SimpleModule,
-      Simditor);
+    root['SimditorAutosave'] = factory(jQuery,SimpleModule,Simditor);
   }
 }(this, function ($, SimpleModule, Simditor) {
 
 var SimditorAutosave,
-  __hasProp = {}.hasOwnProperty,
-  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+  hasProp = {}.hasOwnProperty;
 
-SimditorAutosave = (function(_super) {
-  __extends(SimditorAutosave, _super);
+SimditorAutosave = (function(superClass) {
+  extend(SimditorAutosave, superClass);
 
   function SimditorAutosave() {
     return SimditorAutosave.__super__.constructor.apply(this, arguments);
@@ -34,7 +28,8 @@ SimditorAutosave = (function(_super) {
   SimditorAutosave.pluginName = 'Autosave';
 
   SimditorAutosave.prototype.opts = {
-    autosave: false
+    autosave: false,
+    autosave_global_key: false
   };
 
   SimditorAutosave.prototype._init = function() {
@@ -44,11 +39,15 @@ SimditorAutosave = (function(_super) {
     if (!this.opts.autosave) {
       return;
     }
-    link = $("<a/>", {
-      href: location.href
-    });
-    path = "/" + link[0].pathname.replace(/\/$/g, "").replace(/^\//g, "") + "/";
-    path = path + this.opts.autosave + "/autosave/";
+    if (!this.opts.autosave_global_key) {
+      link = $("<a/>", {
+        href: location.href
+      });
+      path = "/" + link[0].pathname.replace(/\/$/g, "").replace(/^\//g, "") + "/";
+      path = path + this.opts.autosave + "/autosave/";
+    } else {
+      path = "/" + this.opts.autosave + "/autosave/global/" + this.opts.autosave_global_key;
+    }
     this.editor.on("valuechanged", (function(_this) {
       return function() {
         return _this.storage.set(path, _this.editor.getValue());

--- a/src/simditor-autosave.coffee
+++ b/src/simditor-autosave.coffee
@@ -5,15 +5,19 @@ class SimditorAutosave extends SimpleModule
 
   opts:
     autosave: false
+    autosave_global_key: false
 
   _init: () ->
     @editor = @_module
     @opts.autosave = @opts.autosave || @editor.textarea.data('autosave')
     return unless @opts.autosave
 
-    link = $( "<a/>", {href: location.href})
-    path = "/" + link[0].pathname.replace( /\/$/g, "" ).replace( /^\//g, "" ) + "/"
-    path = path + @opts.autosave + "/autosave/"
+    unless @opts.autosave_global_key
+      link = $( "<a/>", {href: location.href})
+      path = "/" + link[0].pathname.replace( /\/$/g, "" ).replace( /^\//g, "" ) + "/"
+      path = path + @opts.autosave + "/autosave/"
+    else
+      path = "/" + @opts.autosave + "/autosave/global/" + @opts.autosave_global_key
 
     @editor.on "valuechanged", =>
       @storage.set path, @editor.getValue()


### PR DESCRIPTION
在一些使用ajax的情况下，多个页面很可能会共享同一个编辑器（内容也会共享）。
